### PR TITLE
Add step to CI workflow to smoke test package plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,8 @@ jobs:
       - name: Build
         run: swift build -v
 
+      - name: Smoke test plugin
+        run: swift package plugin --allow-writing-to-package-directory replay --help
+
       - name: Test
         run: swift test -v


### PR DESCRIPTION
Run `swift package plugin replay --help --allow-writing-to-package-directory` in CI workflow