### PR TITLE
chore: ensure directory exists before saving har

### DIFF
--- a/Sources/Replay/HAR.swift
+++ b/Sources/Replay/HAR.swift
@@ -787,6 +787,13 @@ extension HAR {
     /// with fractional seconds and pretty-printed output.
     public static func save(_ log: Log, to url: URL) throws {
         let data = try encode(log)
+
+        // Ensure the directory exists
+        let directory = url.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+
         try data.write(to: url)
     }
 

--- a/Tests/ReplayTests/HARTests.swift
+++ b/Tests/ReplayTests/HARTests.swift
@@ -1319,6 +1319,24 @@ struct HARTests {
             #expect(log.creator.name == "MyApp/2.0")
         }
 
+        @Test("save to non existing directory")
+        func saveToNonExistingDirectory() throws {
+            var log = HAR.create()
+            log.entries.append(makeTestEntry())
+            log.comment = "Test HAR file"
+
+            let tempSubdirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("subdir")
+            let tempURL = tempSubdirURL
+                .appendingPathComponent("HARTests_saveAndLoad.har")
+
+            try HAR.save(log, to: tempURL)
+
+            #expect(FileManager.default.fileExists(atPath: tempURL.path))
+
+            try? FileManager.default.removeItem(at: tempSubdirURL)
+        }
+
         @Test("save and load roundtrip")
         func saveAndLoad() throws {
             var log = HAR.create()


### PR DESCRIPTION
Ensure the path to the `.har` file exists before saving it. 

Fixes: https://github.com/mattt/Replay/issues/12