### PR TITLE
Raise minimum iOS deployment target to 15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [
         .macOS(.v10_15),
         .macCatalyst(.v13),
-        .iOS(.v13),
+        .iOS(.v15),
         .tvOS(.v13),
         .watchOS(.v6),
         .visionOS(.v1),


### PR DESCRIPTION
Resolves #15.

Xcode 27 beta no longer supports iOS deployment targets below **iOS 15**. Because `Package.swift` declares `.iOS(.v13)`, building Replay under Xcode 27 emits a `the iOS deployment target ... is set to 13.0, but the range of supported deployment target versions is 15.0 to ...` warning.

This bumps the iOS platform floor from `.iOS(.v13)` to `.iOS(.v15)` so the package builds cleanly under Xcode 27. No source changes are required — Replay does not use any API gated below iOS 15.

### Change
```diff
-        .iOS(.v13),
+        .iOS(.v15),
```